### PR TITLE
Parse route query parameters for use in component props

### DIFF
--- a/core/router.js
+++ b/core/router.js
@@ -57,10 +57,13 @@ function resolve(routes, context) {
     }
 
     if (route.query) {
-      for (let key in route.query) {
-        let queryParam = route.query[key];
-        route.query[key] = context.query[queryParam];
-      }
+      Object.keys(route.query).forEach(key => {
+        const queryParam = route.query[key];
+
+        if (context.query) {
+          route.query[key] = context.query[queryParam];
+        }
+      });
     }
 
     // Check if the route has any data requirements, for example:

--- a/core/router.js
+++ b/core/router.js
@@ -56,6 +56,13 @@ function resolve(routes, context) {
       continue;
     }
 
+    if (route.query) {
+      for (let key in route.query) {
+        let queryParam = route.query[key];
+        route.query[key] = context.query[queryParam];
+      }
+    }
+
     // Check if the route has any data requirements, for example:
     // { path: '/tasks/:id', data: { task: 'GET /api/tasks/$id' }, page: './pages/task' }
     if (route.data) {

--- a/docs/routing-and-navigation.md
+++ b/docs/routing-and-navigation.md
@@ -107,6 +107,18 @@ route that needs to fetch a task by its ID may look like this:
 }
 ```
 
+If a route contains some Query Parameters for the given route, these can be passed down as props when configured. The key is desried prop key and the value is the query parameter key received:
+
+```json
+{
+  "path": "/tasks",
+  "page": "./pages/tasks/details",
+  "query": {
+    "status": "status",
+  }
+}
+```
+
 Finally, you can hook the router's `resolve(..)` method to be called each time when a user navigates
 (transitions) between pages. The code for that may look something like this:
 

--- a/docs/routing-and-navigation.md
+++ b/docs/routing-and-navigation.md
@@ -107,7 +107,7 @@ route that needs to fetch a task by its ID may look like this:
 }
 ```
 
-If a route contains some Query Parameters for the given route, these can be passed down as props when configured. The key is desried prop key and the value is the query parameter key received:
+If a route contains query parameters, these can be passed down as props when configured in routes.json. The key is the desired prop key and the value is the query parameter key received:
 
 ```json
 {

--- a/routes.json
+++ b/routes.json
@@ -21,10 +21,10 @@
     "page": "./pages/home"
   },
   {
-    "path": "/tasks",
-    "page": "./pages/home",
+    "path": "/search",
+    "page": "./pages/about",
     "query": {
-      "status": "status"
+      "text": "text"
     }
   }
 ]

--- a/routes.json
+++ b/routes.json
@@ -19,5 +19,12 @@
   {
     "path": "/tasks/:status(pending|completed)?",
     "page": "./pages/home"
+  },
+  {
+    "path": "/tasks",
+    "page": "./pages/home",
+    "query": {
+      "status": "status"
+    }
   }
 ]

--- a/utils/routes-loader.js
+++ b/utils/routes-loader.js
@@ -60,6 +60,9 @@ module.exports = function routesLoader(source) {
     if (route.data) {
       output.push(`    data: ${JSON.stringify(route.data)},\n`);
     }
+    if (route.query) {
+      output.push(`    query: ${JSON.stringify(route.query)},\n`);
+    }
     output.push(`    load() {\n      return ${require(route.page)};\n    },\n`);
     output.push('  },\n');
   }


### PR DESCRIPTION
Routes that use query parameters i.e. `/search?text=bob` can now be passed down as component props if configured in routes.json

This does not interfere with any data or fetch configurations i.e. `/products/123?price=usd` can still make fetch requests using the url parameter and pass the query parameters as props.

In the future it may make sense to add the ability to use query parameters as fetch parameters.
