### PR TITLE
fix: add header.referer for server-side GCP API key http restriction support

### DIFF
--- a/src/authenticate.js
+++ b/src/authenticate.js
@@ -43,6 +43,9 @@ export default async function authenticate(req, res, next) {
               refresh_token: tokens[1],
             },
             json: true,
+            headers: {
+              Referer: req.protocol + '://' + req.get('host') + req.originalUrl,
+            },
           });
           req.user = await firebase.auth().verifyIdToken(idToken);
           res.cookie(sessKey, `${idToken}:${tokens[1]}`, sessOpt);

--- a/src/authenticate.js
+++ b/src/authenticate.js
@@ -44,7 +44,7 @@ export default async function authenticate(req, res, next) {
             },
             json: true,
             headers: {
-              Referer: req.protocol + '://' + req.get('host') + req.originalUrl,
+              Referer: `${req.protocol}://${req.get('host')}${req.originalUrl}`,
             },
           });
           req.user = await firebase.auth().verifyIdToken(idToken);


### PR DESCRIPTION
This can be used to restrict access to API key usage in GCP:

![image](https://user-images.githubusercontent.com/197134/37561129-bfebcee2-2a57-11e8-8810-a08959a9b898.png)
