### PR TITLE
fix: add header.referer for server-side GCP API key http restriction support

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,7 @@
+#
+# CAUTION: do not put sensitive information here. Instead, create .env.local
+#
+
 # Firebase
 # https://console.firebase.google.com/project/_/settings/general/
 # https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ $ yarn test                        # Run unit tests. Or, `yarn test -- --watch`
 2.  Open your Google Cloud project in **Firebase** dashboard and configure Facebook authentication.
 3.  Update Firebase project IDs for production and development environments in `.firebaserc` file.
 4.  Save Firebase API key, authentication domain and GPC service key in Firebase Functions
-    environment. For example `firebase functions:config:set api.browserkey="..." auth.domain="..."`
+    environment. For example `firebase functions:config:set api.browserkey="..." api.serverkey="..." auth.domain="..."`
 5.  Update database host/user/password in either `.env` or `.env.local` file and migrate your
     Cloud SQL database schema to the latest version by running `yarn db-migrate`.
 6.  Finally, deploy your application by running:

--- a/src/authenticate.js
+++ b/src/authenticate.js
@@ -24,6 +24,9 @@ export default async function authenticate(req, res, next) {
   // Try to obtain Firebase ID and refresh tokens from the session cookie
   const cookies = req.headers.cookie || '';
   const tokens = (cookie.parse(cookies)[sessKey] || '').split(':');
+  const referer = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
+
+  req.referer = referer;
 
   // Check if the provided Firebase ID token is valid
   if (tokens[0]) {
@@ -33,7 +36,7 @@ export default async function authenticate(req, res, next) {
     } catch (err) {
       if (err.message.includes('auth/id-token-expired') && tokens[1]) {
         try {
-          const { id_token: idToken } = await token.renew(tokens[1]);
+          const { id_token: idToken } = await token.renew(tokens[1], referer);
           req.user = await firebase.auth().verifyIdToken(idToken);
           res.cookie(sessKey, `${idToken}:${tokens[1]}`, sessOpt);
         } catch (renewError) {

--- a/src/graphql/Context.js
+++ b/src/graphql/Context.js
@@ -21,6 +21,7 @@ class Context {
     this.user = userFromToken(req.user);
     this.signIn = req.signIn;
     this.signOut = req.signOut;
+    this.referer = req.referer;
   }
 
   addError(key, message) {

--- a/src/graphql/user/mutations.js
+++ b/src/graphql/user/mutations.js
@@ -108,7 +108,7 @@ export const signIn = mutationWithClientMutationId({
     // Save database user ID in the Firebase account
     if (!customClaims.id) {
       await auth.setCustomUserClaims(uid, { id, ...customClaims });
-      ({ id_token: idToken } = await token.renew(refreshToken));
+      ({ id_token: idToken } = await token.renew(refreshToken, ctx.referer));
     }
 
     // Save both Firebase ID token and refresh token in a session cookie

--- a/src/token.js
+++ b/src/token.js
@@ -12,7 +12,7 @@ import { config } from 'firebase-functions';
 const apiKey = process.env.FIREBASE_API_SERVER_KEY || config().api.serverkey;
 
 export default {
-  renew(refreshToken) {
+  renew(refreshToken, referer) {
     return request.post({
       url: `https://securetoken.googleapis.com/v1/token?key=${apiKey}`,
       form: {
@@ -20,6 +20,7 @@ export default {
         refresh_token: refreshToken,
       },
       json: true,
+      headers: { referer },
     });
   },
 };


### PR DESCRIPTION
This can be used to restrict access to API key usage in GCP:

![image](https://user-images.githubusercontent.com/197134/37561129-bfebcee2-2a57-11e8-8810-a08959a9b898.png)
