### PR TITLE
Fix pg ssl condition

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -20,7 +20,7 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 // https://github.com/tgriesser/knex/issues/852
-if (process.env.PGSSLMODE || process.env.PGSSLMODE !== 'disable') {
+if (process.env.PGSSLMODE && process.env.PGSSLMODE !== 'disable') {
   connection.ssl = {
     rejectUnauthorized: false,
     ca: fs.readFileSync(process.env.PGSSLROOTCERT).toString(),


### PR DESCRIPTION
If I set `PGSSLMODE=disable`, it passes this condition because of the first operand and the fact that the operator is "or" `||`. I think that's a bug because you can't disable that SSL block with the way it is. Am I missing something? I changed the operator to `&&` and now I'm able to run `yarn setup` without hitting errors on line 26 for not having set the PGSSL... env vars.