### PR TITLE
Simplify DEV vs TEST vs PROD environments

### DIFF
--- a/.env
+++ b/.env
@@ -7,11 +7,11 @@ REACT_APP_NAME=React Starter Kit for Firebase
 # https://console.firebase.google.com/project/_/settings/general/
 # https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk
 
-GCP_PROJECT=react-firebase-graphql
+GCP_PROJECT=example-dev
 GCP_BROWSER_KEY=AIzaSyAsuqpqt29-TIwBAu01Nbt5QnC3FIKO4A4
 GCP_SERVER_KEY=AIzaSyAsuqpqt29-TIwBAu01Nbt5QnC3FIKO4A4
-# GCP_SERVICE_KEY={"type":"service_account","project_id":"react-firebase-graphql","private_key_id":"...","private_key":"...","client_email":"...","client_id":"...","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://accounts.google.com/o/oauth2/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url":"..."}
-FIREBASE_AUTH_DOMAIN=firebase.reactstarter.com
+# GCP_SERVICE_KEY={"type":"service_account","project_id":"example-dev","private_key_id":"...","private_key":"...","client_email":"...","client_id":"...","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://accounts.google.com/o/oauth2/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url":"..."}
+FIREBASE_AUTH_DOMAIN=example-dev.firebaseapp.com
 
 # Authentication
 
@@ -31,7 +31,7 @@ PGHOST=localhost
 PGUSER=postgres
 PGDATABASE=app
 PGPASSWORD=
-PGAPPNAME=rsk
+PGAPPNAME=rsk_dev
 # PGSSLMODE=require
 # PGSSLCERT=./ssl/client-cert.pem
 # PGSSLKEY=./ssl/client-key.pem

--- a/.env.test
+++ b/.env.test
@@ -3,11 +3,11 @@
 # https://console.firebase.google.com/project/_/settings/general/
 # https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk
 
-GCP_PROJECT=example-prod
+GCP_PROJECT=example-test
 GCP_BROWSER_KEY=AIzaSyAsuqpqt29-TIwBAu01Nbt5QnC3FIKO4A4
 GCP_SERVER_KEY=AIzaSyAsuqpqt29-TIwBAu01Nbt5QnC3FIKO4A4
-# GCP_SERVICE_KEY={"type":"service_account","project_id":"example-prod","private_key_id":"...","private_key":"...","client_email":"...","client_id":"...","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://accounts.google.com/o/oauth2/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url":"..."}
-FIREBASE_AUTH_DOMAIN=example-prod.firebaseapp.com
+# GCP_SERVICE_KEY={"type":"service_account","project_id":"example-test","private_key_id":"...","private_key":"...","client_email":"...","client_id":"...","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://accounts.google.com/o/oauth2/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url":"..."}
+FIREBASE_AUTH_DOMAIN=example-test.firebaseapp.com
 
 # Authentication
 
@@ -27,8 +27,8 @@ PGHOST=/cloudbuild/<project-id>:<region>:<db-instance>
 PGUSER=<user>
 PGDATABASE=<database>
 PGPASSWORD=<password>
-PGAPPNAME=rsk
+PGAPPNAME=rsk_test
 
 # Analytics
 
-GA_TRACKING_ID=UA-XXXXX-Y
+GA_TRACKING_ID=

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ This project was bootstraped with [React Starter Kit for Firebase][rfs] by [Kria
 
 ### Tech Stack
 
-- [Create React App][cra] (★ 55k) for development and test infrastructure (see [user guide][cradocs])
-- [Material UI][mui] (★ 40k) to reduce development time by integrating Google's [Material Design][material]
-- [Passport.js][passport] (★ 14k) for authentication configured with stateless JWT tokens for sessions
-- [GraphQL.js][gqljs] (★ 11k) and [Relay][relay] (★ 11k) for declarative data fetching and efficient client stage management
+- [Create React App][cra] (★ 64k) for development and test infrastructure (see [user guide][cradocs])
+- [Material UI][mui] (★ 45k) to reduce development time by integrating Google's [Material Design][material]
+- [Passport.js][passport] (★ 15k) for authentication configured with stateless JWT tokens for sessions
+- [GraphQL.js][gqljs] (★ 13k) and [Relay][relay] (★ 11k) for declarative data fetching and efficient client stage management
 - [Universal Router][router] (★ 1k) + [history][history] (★ 3k) for declarative routing and client-side navigation optimized for [Relay][relay]
-- [PostgreSQL][psql] database pre-configured with a query builder and migrations using [Knex.js][knex] (★ 6k)
+- [PostgreSQL][psql] database pre-configured with a query builder and migrations using [Knex.js][knex] (★ 10k)
 - [Google Cloud][gcp] & [Firebase][firebase] for serverless architecture - Cloud SQL, Cloud Functions, CDN hosting, file storage ([docs][fbdocs])
 
 Also, you need to be familiar with [HTML][html], [CSS][css], [JavaScript][js] ([ES2015][es2015]) and [React](https://reactjs.org/docs/).
@@ -53,6 +53,7 @@ Also, you need to be familiar with [HTML][html], [CSS][css], [JavaScript][js] ([
 │   ├── admin/                     # Admin section (Dashboard, User Management etc.)
 │   ├── common/                    # Shared React components and HOCs
 │   ├── icons/                     # Icon components
+│   ├── legal/                     # Terms of Use, Privacy Policy, etc.
 │   ├── news/                      # News section (example)
 │   ├── pages/                     # Static pages (landing, about, privacy, etc.)
 │   ├── server/                    # Server-side code (API, authentication, etc.)
@@ -75,14 +76,16 @@ Also, you need to be familiar with [HTML][html], [CSS][css], [JavaScript][js] ([
 │   └── theme.js                   # Overrides for Material UI default styles
 ├── ssl/                           # SSL certificates for connecting to Cloud SQL instance
 ├── .env                           # Environment variables
-├── .env.local                     # Local (development) overrides
+├── .env.local                     # Environment variables overrides for local development
+├── .env.production                # Environment variables overrides for PROD environment
+├── .env.test                      # Environment variables overrides for TEST environment
 ├── graphql.schema                 # GraphQL schema (auto-generated, used by Relay)
 └── package.json                   # The list of project dependencies + NPM scripts
 ```
 
 ### Prerequisites
 
-- [Node.js][nodejs] v8.11 or higher + [Yarn][yarn] v1.6 or higher &nbsp; (_HINT: On Mac install
+- [Node.js][nodejs] v8.15 or higher + [Yarn][yarn] v1.13 or higher &nbsp; (_HINT: On Mac install
   them via [Brew][brew]_)
 - [VS Code][vc] editor (preferred) + [Project Snippets][vcsnippets], [EditorConfig][vceditconfig],
   [ESLint][vceslint], [Flow][vcflow], [Prettier][vcprettier], and [Babel JavaScript][vcjs] plug-ins
@@ -116,8 +119,8 @@ $ yarn db-seed                     # Seed database with previously saved data
 $ yarn db                          # Open PostgreSQL shell (for testing/debugging)
 ```
 
-**Note**: Appending `--env=production` flag to any of the commands above will force it to use
-database connection settings from `.env.production` and/or `.env.production.local` file(s).
+**Note**: Appending `--prod` / `--test` flags to any of the commands above will force it to use
+database connection settings from `.env.production` and/or `.env.test` file(s).
 
 ### How to Test
 
@@ -133,8 +136,8 @@ $ yarn test                        # Run unit tests. Or, `yarn test -- --watch`
 2.  Configure authentication in **Firebase** dashboard.
 3.  Set Firebase project ID in `.firebaserc` file.
 4.  Set API keys, secrets and other settings in `.env.production` file.
-5.  Migrate the database by running `NODE_ENV=production yarn db-migrate`.
-6.  Finally, deploy your application by running `yarn deploy`.
+5.  Migrate the database by running `yarn db-migrate --prod`.
+6.  Finally, deploy your application by running `yarn deploy-prod`.
 
 ### How to Update
 

--- a/knexfile.js
+++ b/knexfile.js
@@ -7,7 +7,13 @@
 const fs = require('fs');
 const dotenv = require('dotenv');
 
-dotenv.config({ path: `.env.${process.env.NODE_ENV}` });
+const env = process.argv.includes('--prod')
+  ? 'production'
+  : process.argv.includes('--test')
+  ? 'test'
+  : '';
+
+dotenv.config({ path: `.env.${env}` });
 dotenv.config({ path: '.env.local' });
 dotenv.config({ path: '.env' });
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "db-rollback": "knex migrate:rollback",
     "db-seed": "knex seed:run",
     "db-version": "knex migrate:currentVersion",
-    "deploy": "yarn install && yarn relay && yarn build && firebase deploy"
+    "deploy": "firebase --project=example-test deploy",
+    "deploy-prod": "firebase --project=example-prod deploy"
   }
 }

--- a/scripts/db.js
+++ b/scripts/db.js
@@ -4,15 +4,15 @@
  * Copyright (c) 2015-present Kriasoft | MIT License
  */
 
-const dotenv = require('dotenv');
 const cp = require('child_process');
 
-dotenv.config({ path: `.env.${process.env.NODE_ENV}` });
-dotenv.config({ path: '.env.local' });
-dotenv.config({ path: '.env' });
+// Load environment variables (PGHOST, PGUSER, etc.)
+require('../knexfile');
 
+// Ensure that the SSL key file has correct permissions
 if (process.env.PGSSLKEY) {
   cp.spawnSync('chmod', ['0600', process.env.PGSSLKEY], { stdio: 'inherit' });
 }
 
+// Launch interactive terminal for working with Postgres
 cp.spawn('psql', { stdio: 'inherit' });

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -11,7 +11,12 @@ const express = require('express');
 const firebase = require('firebase-admin');
 const functions = require('firebase-functions');
 
-dotenv.config({ path: `.env.${process.env.NODE_ENV}` });
+// Infer runtime environment from the project's name, for example:
+//   "example-prod" => "prod"
+//   "example-test" => "test"
+const [, env] = (x => x && x.match(/-(\w+)$/))(process.env.GCP_PROJECT) || [];
+
+dotenv.config({ path: `.env.${env === 'prod' ? 'production' : env}` });
 dotenv.config({ path: '.env.local' });
 dotenv.config({ path: '.env' });
 


### PR DESCRIPTION
This is a light-weight approach for working with different environments - `dev` (aka `local`), `test`, and `prod` (aka `production`). For example, you can now migrate either of these three databases without hooking into CI or switching between branches:

```bash
$ yarn db-migrate             # Migrates local database
$ yarn db-migrate --test      # Migrates TEST database
$ yarn db-migrate --prod      # Migrates PROD database
```

```bash
$ yarn deploy                 # Deploys the app to TEST server (default)
$ yarn deploy-prod            # Deploys the app to PROD server
```

In order to protect the production secrets, you can either add `.env.prod` to `.gitignore`, or encode some of the values and decode them on the fly during deployment (this would be done on CI).