### PR TITLE
Update universal-router to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "request-promise-native": "^1.0.7",
     "serialize-javascript": "^1.7.0",
     "slug": "^1.1.0",
-    "universal-router": "^8.2.0",
+    "universal-router": "^8.2.1",
     "uuid": "^3.3.2",
     "validator": "^11.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12399,10 +12399,10 @@ unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
   integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
 
-universal-router@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/universal-router/-/universal-router-8.2.0.tgz#09b9333ffb022b4ab367e2af589efb5bca1d7ccf"
-  integrity sha512-QuCJiIv+QqPCKCU1dKJVtqBwGUn6RvkIiaHuUoy2cjcNa43Opl2bCUSisCe4AC/hSXFyHdUFB0k0iK8S7Ib2Gg==
+universal-router@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/universal-router/-/universal-router-8.2.1.tgz#bf7b5fb0a9514c897a03adce75c60285759855d6"
+  integrity sha512-P9rOUVIseSEDoJPjJvWhazjCwXwiaqKcv+1FMsI62XYrKAHiKVGgRh1VtAnv3hSwni6vkJxhosXIK+NWGVz7sg==
   dependencies:
     path-to-regexp "^3.0.0"
 


### PR DESCRIPTION
<details>
<summary>Release Notes for 8.2.1 - 2019-07-20</summary>

<ul>
<li>Fix <code>context.next()</code> to throw <code>Route not found</code> instead of <code>TypeError</code> (<a href="https://urls.greenkeeper.io/kriasoft/universal-router/pull/169" data-hovercard-type="pull_request" data-hovercard-url="/kriasoft/universal-router/pull/169/hovercard">#169</a>)</li>
</ul>
</details>